### PR TITLE
remove requirement for python <3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - matplotlib-base >=2.0
     - numpy >=1.9
     - pandas
-    - python >=3.7,<3.12
+    - python >=3.7
     - scipy >=0.16
     - seaborn
     - pytorch >=1.11.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,14 @@ source:
   sha256: 5c59401b3e884049d0fa72f8f415442930bd1cc3647ddbf1340d49a5b0947ca3
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7,<3.12
+    - python >=3.7
     - setuptools
     - setuptools-scm
   run:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

nessai now supports Python 3.12 so the recipe should be updated to reflect that.
